### PR TITLE
Add docker/login-action to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
+          
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: sqrereadonly
+          password: ${{ secrets.DOCKERHUB_SQREREADONLY_TOKEN }}
 
       - name: Python install
         run: |


### PR DESCRIPTION
This will prevent Docker Hub from rate-limiting builds of this document.